### PR TITLE
Build a proof of existence dApp

### DIFF
--- a/src/TemplateModule.js
+++ b/src/TemplateModule.js
@@ -1,70 +1,127 @@
-import React, { useEffect, useState } from 'react'
-import { Form, Input, Grid, Card, Statistic } from 'semantic-ui-react'
+// React and Semantic UI elements.
+import React, { useState, useEffect } from 'react'
+import { Form, Input, Grid, Message } from 'semantic-ui-react'
 
+// Pre-built Substrate front-end utilities for connecting to a node
+// and making a transaction.
 import { useSubstrateState } from './substrate-lib'
 import { TxButton } from './substrate-lib/components'
 
-function Main(props) {
+// Polkadot-JS utilities for hashing data.
+import { blake2AsHex } from '@polkadot/util-crypto'
+
+// Main Proof Of Existence component is exported.
+export function Main(props) {
+  // Establish an API to talk to the Substrate node.
   const { api } = useSubstrateState()
-
-  // The transaction submission status
+  // Get the selected user from the `AccountSelector` component.
+  const { accountPair } = props
+  // React hooks for all the state variables we track.
+  // Learn more at: https://reactjs.org/docs/hooks-intro.html
   const [status, setStatus] = useState('')
+  const [digest, setDigest] = useState('')
+  const [owner, setOwner] = useState('')
+  const [block, setBlock] = useState(0)
+  // Our `FileReader()` which is accessible from our functions below.
+  let fileReader
+  // Takes our file, and creates a digest using the Blake2 256 hash function
+  const bufferToDigest = () => {
+    // Turns the file content to a hexadecimal representation.
+    const content = Array.from(new Uint8Array(fileReader.result))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('')
+    const hash = blake2AsHex(content, 256)
+    setDigest(hash)
+  }
 
-  // The currently stored value
-  const [currentValue, setCurrentValue] = useState(0)
-  const [formValue, setFormValue] = useState(0)
+  // Callback function for when a new file is selected.
+  const handleFileChosen = file => {
+    fileReader = new FileReader()
+    fileReader.onloadend = bufferToDigest
+    fileReader.readAsArrayBuffer(file)
+  }
 
+  // React hook to update the owner and block number information for a file
   useEffect(() => {
     let unsubscribe
+    // Polkadot-JS API query to the `proofs` storage item in our pallet.
+    // This is a subscription, so it will always get the latest value,
+    // even if it changes.
     api.query.templateModule
-      .something(newValue => {
-        // The storage value is an Option<u32>
-        // So we have to check whether it is None first
-        // There is also unwrapOr
-        if (newValue.isNone) {
-          setCurrentValue('<None>')
-        } else {
-          setCurrentValue(newValue.unwrap().toNumber())
-        }
+      .proofs(digest, result => {
+        // Our storage item returns a tuple, which is represented as an array.
+        setOwner(result[0].toString())
+        setBlock(result[1].toNumber())
       })
       .then(unsub => {
         unsubscribe = unsub
       })
-      .catch(console.error)
-
     return () => unsubscribe && unsubscribe()
-  }, [api.query.templateModule])
+    // This tells the React hook to update whenever the file digest changes
+    // (when a new file is chosen), or when the storage subscription says the
+    // value of the storage item has updated.
+  }, [digest, api.query.templateModule])
 
+  // We can say a file digest is claimed if the stored block number is not 0
+  function isClaimed() {
+    return block !== 0
+  }
+
+  // The actual UI elements which are returned from our component.
   return (
-    <Grid.Column width={8}>
-      <h1>Template Module</h1>
-      <Card centered>
-        <Card.Content textAlign="center">
-          <Statistic label="Current Value" value={currentValue} />
-        </Card.Content>
-      </Card>
-      <Form>
+    <Grid.Column>
+      <h1>Proof of Existence</h1>
+      {/* Show warning or success message if the file is or is not claimed. */}
+      <Form success={!!digest && !isClaimed()} warning={isClaimed()}>
         <Form.Field>
+          {/* File selector with a callback to `handleFileChosen`. */}
           <Input
-            label="New Value"
-            state="newValue"
-            type="number"
-            onChange={(_, { value }) => setFormValue(value)}
+            type="file"
+            id="file"
+            label="Your File"
+            onChange={e => handleFileChosen(e.target.files[0])}
+          />
+          {/* Show this message if the file is available to be claimed */}
+          <Message success header="File Digest Unclaimed" content={digest} />
+          {/* Show this message if the file is already claimed. */}
+          <Message
+            warning
+            header="File Digest Claimed"
+            list={[digest, `Owner: ${owner}`, `Block: ${block}`]}
           />
         </Form.Field>
-        <Form.Field style={{ textAlign: 'center' }}>
+        {/* Buttons for interacting with the component. */}
+        <Form.Field>
+          {/* Button to create a claim. Only active if a file is selected, and not already claimed. Updates the `status`. */}
           <TxButton
-            label="Store Something"
-            type="SIGNED-TX"
+            accountPair={accountPair}
+            label={'Create Claim'}
             setStatus={setStatus}
+            type="SIGNED-TX"
+            disabled={isClaimed() || !digest}
             attrs={{
               palletRpc: 'templateModule',
-              callable: 'doSomething',
-              inputParams: [formValue],
+              callable: 'createClaim',
+              inputParams: [digest],
+              paramFields: [true],
+            }}
+          />
+          {/* Button to revoke a claim. Only active if a file is selected, and is already claimed. Updates the `status`. */}
+          <TxButton
+            accountPair={accountPair}
+            label="Revoke Claim"
+            setStatus={setStatus}
+            type="SIGNED-TX"
+            disabled={!isClaimed()}
+            attrs={{
+              palletRpc: 'templateModule',
+              callable: 'revokeClaim',
+              inputParams: [digest],
               paramFields: [true],
             }}
           />
         </Form.Field>
+        {/* Status message about the transaction. */}
         <div style={{ overflowWrap: 'break-word' }}>{status}</div>
       </Form>
     </Grid.Column>
@@ -73,7 +130,7 @@ function Main(props) {
 
 export default function TemplateModule(props) {
   const { api } = useSubstrateState()
-  return api.query.templateModule && api.query.templateModule.something ? (
+  return api.query.templateModule && api.query.templateModule.proofs ? (
     <Main {...props} />
   ) : null
 }


### PR DESCRIPTION
complete: https://docs.substrate.io/tutorials/v3/proof-of-existence/

# diff from tutorial
- should use `useSubstrateState` instead of `useSubstrate` to Instantiate api
- `disabled={!isClaimed() || owner !== accountPair.address}` doesn't work because accountPair is not provided as props
  - in [solution branch](https://github.com/substrate-developer-hub/substrate-front-end-template/blob/tutorials/solutions/proof-of-existence/src/AccountSelector.js), we can see how to set accountPair as global state, but it seems to be outdated